### PR TITLE
Update to complexipy v4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-RUN pip install complexipy==3.1.0
+RUN pip install complexipy==4.2.0
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -23,15 +23,17 @@ jobs:
 
 ## Inputs
 
-| Input               | Description                                                                                                                      | Required | Default                   |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------- |
-| `paths`             | Paths to analyze. Can be local paths or a git repository URL.                                                                    | No      | `""` |
-| `ignore_complexity` | Ignore complexity threshold and show all functions. By default, complexipy will fail if a function exceeds a certain complexity. | No       | `false`                   |
-| `output_csv`        | Generate results in a CSV file.                                                                                                  | No       | `false`                   |
-| `output_json`       | Generate results in a JSON file.                                                                                                 | No       | `false`                   |
-| `details`           | Output detail level (`low` or `normal`).                                                                                         | No       | `normal`                  |
-| `quiet`             | Suppress console output.                                                                                                         | No       | `false`                   |
-| `sort`              | Sort results by complexity (`asc`, `desc`, or `name`).                                                                           | No       | `asc`                     |
+| Input                    | Description                                                                                       |
+| ------------------------ | ------------------------------------------------------------------------------------------------- |
+| `paths`                  | Paths to analyze. Can be local paths or a git repository URL. If not provided, uses pyproject.toml configuration. |
+| `exclude`                | Paths to the directories or files to exclude.                                                     |
+| `max_complexity_allowed` | Max complexity allowed per function.                                                              |
+| `ignore_complexity`      | Ignore complexity threshold and show all functions.                                               |
+| `output_csv`             | Generate results in a CSV file.                                                                   |
+| `output_json`            | Generate results in a JSON file.                                                                  |
+| `details`                | Output detail level (`low` or `normal`).                                                          |
+| `quiet`                  | Suppress console output.                                                                          |
+| `sort`                   | Sort results by complexity (`asc`, `desc`, or `name`).                                            |
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ jobs:
     - uses: actions/checkout@v4
     - name: Check Python Code Complexity
       uses: rohaquinlop/complexipy-action@v3
-      with:
-        paths: '.'  # Analyze the entire repository
-        ignore_complexity: false # Set to true to ignore complexity checks
 ```
 
 ## Inputs
@@ -40,10 +37,10 @@ jobs:
 
 ### Basic Usage
 
+This will look at the pyproject.toml or complexipy.toml, etc.
+
 ```yaml
 - uses: rohaquinlop/complexipy-action@v3
-  with:
-    paths: '.'
 ```
 
 ### Ignore Complexity Threshold

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
 
 | Input               | Description                                                                                                                      | Required | Default                   |
 | ------------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------- |
-| `paths`             | Paths to analyze. Can be local paths or a git repository URL.                                                                    | Yes      | `${{ github.workspace }}` |
+| `paths`             | Paths to analyze. Can be local paths or a git repository URL.                                                                    | No      | `""` |
 | `ignore_complexity` | Ignore complexity threshold and show all functions. By default, complexipy will fail if a function exceeds a certain complexity. | No       | `false`                   |
 | `output_csv`        | Generate results in a CSV file.                                                                                                  | No       | `false`                   |
 | `output_json`       | Generate results in a JSON file.                                                                                                 | No       | `false`                   |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Check Python Code Complexity
-      uses: rohaquinlop/complexipy-action@v3
+      uses: rohaquinlop/complexipy-action@v4
 ```
 
 ## Inputs
@@ -40,13 +40,13 @@ jobs:
 This will look at the pyproject.toml or complexipy.toml, etc.
 
 ```yaml
-- uses: rohaquinlop/complexipy-action@v3
+- uses: rohaquinlop/complexipy-action@v4
 ```
 
 ### Ignore Complexity Threshold
 
 ```yaml
-- uses: rohaquinlop/complexipy-action@v3
+- uses: rohaquinlop/complexipy-action@v4
   with:
     paths: './src'
     ignore_complexity: true
@@ -55,7 +55,7 @@ This will look at the pyproject.toml or complexipy.toml, etc.
 ### Generate CSV Report
 
 ```yaml
-- uses: rohaquinlop/complexipy-action@v3
+- uses: rohaquinlop/complexipy-action@v4
   with:
     paths: '.'
     output_csv: true
@@ -63,7 +63,7 @@ This will look at the pyproject.toml or complexipy.toml, etc.
 
 ### Generate JSON Report
 ```yaml
-- uses: rohaquinlop/complexipy-action@v3
+- uses: rohaquinlop/complexipy-action@v4
   with:
     paths: '.'
     output_json: true
@@ -72,7 +72,7 @@ This will look at the pyproject.toml or complexipy.toml, etc.
 ### Analyze Specific Directory with Low Detail Output
 
 ```yaml
-- uses: rohaquinlop/complexipy-action@v3
+- uses: rohaquinlop/complexipy-action@v4
   with:
     paths: './src/python'
     details: 'low'

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,10 @@
 name: complexipy
 description: Calculate the cognitive complexity of Python files, written in Rust.
+
 inputs:
   paths:
-    description: Paths to analyze. Can be local paths or a git repository URL.
-    required: true
-    default: ${{ github.workspace }}
+    description: Paths to analyze (optional). Can be local paths or a git repository URL.
+    required: false
   output_csv:
     description: Generate results in a CSV file.
     required: false
@@ -14,11 +14,11 @@ inputs:
     required: false
     default: 'false'
   ignore_complexity:
-    description: Ignore complexity threshold and show all functions. By default, complexipy will fail if a function exceeds a certain complexity.
+    description: Ignore complexity threshold and show all functions.
     required: false
     default: 'false'
   details:
-    description: 'Output detail level (`low` or `normal`).'
+    description: Output detail level (`low` or `normal`).
     required: false
     default: "normal"
   quiet:
@@ -26,9 +26,10 @@ inputs:
     required: false
     default: 'false'
   sort:
-    description: 'Sort results by complexity (`asc`, `desc`, or `name`).'
+    description: Sort results by complexity (`asc`, `desc`, or `name`).
     required: false
     default: "asc"
+
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -40,6 +41,7 @@ runs:
     - ${{ inputs.details }}
     - ${{ inputs.quiet }}
     - ${{ inputs.sort }}
+
 branding:
   icon: "check-circle"
   color: "purple"

--- a/action.yml
+++ b/action.yml
@@ -1,47 +1,46 @@
 name: complexipy
 description: Calculate the cognitive complexity of Python files, written in Rust.
-
 inputs:
   paths:
     description: Paths to analyze (optional). Can be local paths or a git repository URL.
     required: false
-  output_csv:
-    description: Generate results in a CSV file.
+  exclude:
+    description: Paths to the directories or files to exclude.
     required: false
-    default: 'false'
-  output_json:
-    description: Generate results in a JSON file.
+  max_complexity_allowed:
+    description: Max complexity allowed per function.
     required: false
-    default: 'false'
   ignore_complexity:
     description: Ignore complexity threshold and show all functions.
     required: false
-    default: 'false'
+  output_csv:
+    description: Generate results in a CSV file.
+    required: false
+  output_json:
+    description: Generate results in a JSON file.
+    required: false
   details:
     description: Output detail level (`low` or `normal`).
     required: false
-    default: "normal"
   quiet:
     description: Suppress console output.
     required: false
-    default: 'false'
   sort:
     description: Sort results by complexity (`asc`, `desc`, or `name`).
     required: false
-    default: "asc"
-
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.paths }}
-    - ${{ inputs.ignore_complexity }}
-    - ${{ inputs.output_csv }}
-    - ${{ inputs.output_json }}
-    - ${{ inputs.details }}
-    - ${{ inputs.quiet }}
-    - ${{ inputs.sort }}
-
+  env:
+    PATHS: ${{ inputs.paths }}
+    EXCLUDE: ${{ inputs.exclude }}
+    MAX_COMPLEXITY: ${{ inputs.max_complexity_allowed }}
+    IGNORE_COMPLEXITY: ${{ inputs.ignore_complexity }}
+    OUTPUT_CSV: ${{ inputs.output_csv }}
+    OUTPUT_JSON: ${{ inputs.output_json }}
+    DETAILS: ${{ inputs.details }}
+    QUIET: ${{ inputs.quiet }}
+    SORT: ${{ inputs.sort }}
 branding:
   icon: "check-circle"
   color: "purple"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh -l
 
+if [ $# -eq 0 ]; then
+    exec complexipy
+fi
+
 files=$(echo $1 | tr '\n' ' ')
 
 ignore_complexity=""

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,43 +1,36 @@
 #!/bin/sh -l
 
-if [ $# -eq 0 ]; then
-    exec complexipy
+# Build command arguments
+set --
+
+# Add paths if provided
+if [ -n "$PATHS" ]; then
+    for path in $PATHS; do
+        set -- "$@" "$path"
+    done
 fi
 
-files=$(echo $1 | tr '\n' ' ')
-
-ignore_complexity=""
-if [ "$2" = "true" ]; then
-    ignore_complexity="-i"
+# Add exclude paths if provided
+if [ -n "$EXCLUDE" ]; then
+    for exclude_path in $EXCLUDE; do
+        set -- "$@" "-e" "$exclude_path"
+    done
 fi
 
-output_csv=""
-if [ "$3" = "true" ]; then
-    output_csv="-c"
-fi
+# Add max complexity if provided
+[ -n "$MAX_COMPLEXITY" ] && set -- "$@" "-mx" "$MAX_COMPLEXITY"
 
-output_json=""
-if [ "$4" = "true" ]; then
-    output_json="-j"
-fi
+# Add boolean flags if true
+[ "$IGNORE_COMPLEXITY" = "true" ] && set -- "$@" "-i"
+[ "$OUTPUT_CSV" = "true" ] && set -- "$@" "-c"
+[ "$OUTPUT_JSON" = "true" ] && set -- "$@" "-j"
+[ "$QUIET" = "true" ] && set -- "$@" "-q"
 
-details="-d normal"
-if [ "$5" = "low" ]; then
-    details="-d low"
-fi
+# Add details if provided
+[ -n "$DETAILS" ] && set -- "$@" "-d" "$DETAILS"
 
-quiet=""
-if [ "$6" = "true" ]; then
-    quiet="-q"
-fi
+# Add sort if provided
+[ -n "$SORT" ] && set -- "$@" "-s" "$SORT"
 
-sort=""
-if [ "$7" = "asc" ]; then
-    sort="-s asc"
-elif [ "$7" = "desc" ]; then
-    sort="-s desc"
-elif [ "$7" = "name" ]; then
-    sort="-s name"
-fi
-
-complexipy $files $ignore_complexity $output_csv $output_json $details $quiet $sort
+# Execute complexipy
+exec complexipy "$@"


### PR DESCRIPTION
Make it use the pyproject toml by default if nothing is provided.

Pass in the github action flags iff they are actually provided.

Update README